### PR TITLE
Fixed Safari date issue.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -572,8 +572,7 @@ function amortize(mtg){
     }
     
     var payments = new Array();
-    var runningDate = new Date(mtg['originalstartmonth'] + " 8, " + mtg['originalstartyear'])
-    runningDate.setMonth(runningDate.getMonth()+1);
+    var runningDate = new Date(mtg['originalstartyear'], mtg['originalstartmonth'] + 1, 8, 0, 0, 0, 0);
     if(forwardDate()) {
         runningDate = new Date();
         runningDate.setDate(8);


### PR DESCRIPTION
Hi Dan, 

I like what you've done with paydowncalc.com but noticed it didn't work with Safari. I've found and fixed the issue for you here. 

Chrome was more liberal with what it accepted as a date string and Safari couldn't parse the month number and day seemingly so I reformatted the constructor to be specific to avoid that.